### PR TITLE
Moved `START_JUCE_APPLICATION` to the global scope

### DIFF
--- a/Apps/AudioAppTemplate/Source/Main.cpp
+++ b/Apps/AudioAppTemplate/Source/Main.cpp
@@ -24,7 +24,7 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
 };
 
-// This macro generates the main() routine that launches the app.
-START_JUCE_APPLICATION(GuiAppTemplateApplication)
-
 } // namespace GuiApp
+
+// This macro generates the main() routine that launches the app.
+START_JUCE_APPLICATION(AudioApp::GuiAppTemplateApplication)

--- a/Apps/CustomModuleTest/Source/Main.cpp
+++ b/Apps/CustomModuleTest/Source/Main.cpp
@@ -24,7 +24,7 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
 };
 
-// This macro generates the main() routine that launches the app.
-START_JUCE_APPLICATION(GuiAppTemplateApplication)
-
 } // namespace GuiApp
+
+// This macro generates the main() routine that launches the app.
+START_JUCE_APPLICATION(GuiApp::GuiAppTemplateApplication)

--- a/Apps/GuiAppTemplate/Window/Main.cpp
+++ b/Apps/GuiAppTemplate/Window/Main.cpp
@@ -25,7 +25,7 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
 };
 
-// This macro generates the main() routine that launches the app.
-START_JUCE_APPLICATION(GuiAppTemplateApplication)
-
 } // namespace GuiApp
+
+// This macro generates the main() routine that launches the app.
+START_JUCE_APPLICATION(GuiApp::GuiAppTemplateApplication)

--- a/Apps/SideThreadPaint/Source/Main.cpp
+++ b/Apps/SideThreadPaint/Source/Main.cpp
@@ -24,7 +24,7 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
 };
 
-// This macro generates the main() routine that launches the app.
-START_JUCE_APPLICATION(GuiAppTemplateApplication)
-
 } // namespace GuiApp
+
+// This macro generates the main() routine that launches the app.
+START_JUCE_APPLICATION(GuiApp::GuiAppTemplateApplication)


### PR DESCRIPTION
Hello,

When checking it out JUCECmakeRepoPrototype as of `de10e22` , with JUCE on `develop` at `29e6bee`, building on macOS causes problems because it seems that the `START_JUCE_APPLICATION` macro cannot be nested in a namespace.

The following:

```
cmake -G Ninja -B cmake-ninja-debug-build -DCMAKE_BUILD_TYPE=Debug
cmake --build cmake-ninja-debug-build
```
Leads to link errors (missing `_main`) in the few examples that were using this macro in a namespace. The other examples build and link correctly.

I have also verified that this happens with XCode and, on Windows, with the Visual Studio 2022 x64 configuration. 

Moving the macro outside of the namespace fixes the issue and allows the apps to link and run.

Unsure if that is supposed to work and is a bug in JUCE?
