### PR TITLE
Calling shutdownAudio() in component dtor

### DIFF
--- a/Apps/AudioAppTemplate/Source/MainComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/MainComponent.cpp
@@ -9,6 +9,11 @@ MainComponent::MainComponent()
     setSize(600, 400);
 }
 
+MainComponent::~MainComponent()
+{
+    shutdownAudio();
+}
+
 void MainComponent::paint(Graphics& g)
 {
     g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));

--- a/Apps/AudioAppTemplate/Source/MainComponent.h
+++ b/Apps/AudioAppTemplate/Source/MainComponent.h
@@ -8,6 +8,7 @@ class MainComponent : public juce::AudioAppComponent
 {
 public:
     MainComponent();
+    virtual ~MainComponent() override;
 
     void prepareToPlay(int samplesPerBlockExpected, double sampleRate) override;
     void releaseResources() override;


### PR DESCRIPTION
The audio app template, as it was before the fix, triggers the following :

```
any.AudioAppTemplate.savedState/
JUCE Assertion failure in juce_AudioAppComponent.cpp:54
Process 67014 stopped
* thread #1, name = 'JUCE v8.0.4: Message Thread', queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x10089010c)
    frame #0: 0x0000000100890110 Audio App Template`juce::AudioAppComponent::~AudioAppComponent(this=0x000000012d872600) at juce_AudioAppComponent.cpp:54:5
   51  	{
   52  	    // If you hit this then your derived class must call shutdown audio in
   53  	    // destructor!
-> 54  	    jassert (audioSourcePlayer.getCurrentSource() == nullptr);
   55  	}
   56  	
   57  	void AudioAppComponent::setAudioChannels (int numInputChannels, int numOutputChannels, const XmlElement* const xml)
Target 0: (Audio App Template) stopped.
(lldb) ft
```

It's in debug mode (hence the assert trigger) with JUCE `develop` as of `29e6bee` (with the Xcode 16.2 toolchain)

I think that this Audio App Template is the only place in your repo where `AudioAppComponent` is used and could trigger this assertion.

I take advantage of this to thank you profusely for this 'all-in-one' repo that really helps when starting with JUCE!  🙏

Hope this helps!




